### PR TITLE
동시성 제어 리뷰 부탁드립니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@nestjs/platform-express": "^10.4.20",
         "@nestjs/typeorm": "^10.0.2",
         "class-transformer": "^0.5.1",
-        "dotenv": "^17.2.1",
+        "dotenv": "^17.2.3",
         "mysql2": "^3.9.2",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -4918,9 +4918,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -15397,9 +15397,9 @@
       }
     },
     "dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ=="
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="
     },
     "dotenv-expand": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@nestjs/platform-express": "^10.4.20",
     "@nestjs/typeorm": "^10.0.2",
     "class-transformer": "^0.5.1",
-    "dotenv": "^17.2.1",
+    "dotenv": "^17.2.3",
     "mysql2": "^3.9.2",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:it": "jest --config ./test/it/it.jest.json"
+    "test:it": "jest --config ./test/it/it.jest.json --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/test/it/order-user/order-user.it.spec.ts
+++ b/test/it/order-user/order-user.it.spec.ts
@@ -6,21 +6,29 @@ import { OrderService } from "../../../src/order/usecase/order.service";
 import { UserEntity } from "../../../src/user/entities/user.entity";
 import { ProductEntity } from "../../../src/product/entities/product.entity";
 import { AuthService } from "../../../src/auth/auth.service";
+import { TestingModule } from "@nestjs/testing";
 
 describe("충전 → 주문 잔액 흐름 (Integration)", () => {
   let ds: DataSource;
+  let moduleRef: TestingModule;
   let userSvc: UserService;
   let orderSvc: OrderService;
   let authSvc: AuthService;
 
   beforeAll(async () => {
-    const { moduleRef, dataSource } = await createItModule();
-    ds = dataSource;
+    const setup = await createItModule();
+    moduleRef = setup.moduleRef;
+    ds = setup.dataSource;
     userSvc = moduleRef.get(UserService);
     orderSvc = moduleRef.get(OrderService);
     authSvc = moduleRef.get(AuthService);
   });
-
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy(); // DB 커넥션 풀 닫기
+    }
+    await moduleRef.close(); // Nest 컨테이너 / 내부 타이머 종료
+  });
   beforeEach(async () => {
     await ds.synchronize(true); // 모든 테이블 초기화
 

--- a/test/it/order/balance-concurrency.it.sepc.ts
+++ b/test/it/order/balance-concurrency.it.sepc.ts
@@ -1,0 +1,204 @@
+// test/it/order/order-payment-flow.it.spec.ts
+import { createItModuleMySql } from "../setup.mysql";
+import { DataSource, Repository } from "typeorm";
+import { getRepositoryToken } from "@nestjs/typeorm";
+
+import { AuthService } from "../../../src/auth/auth.service";
+import { UserService } from "../../../src/user/user.service";
+import { OrderService } from "../../../src/order/usecase/order.service";
+
+import { UserEntity } from "../../../src/user/entities/user.entity";
+import { ProductEntity } from "../../../src/product/entities/product.entity";
+import { OrderEntity } from "../../../src/order/adapter/out/order.entity";
+import { OutboxEntity } from "../../../src/order/adapter/out/outbox.entity";
+
+describe("잔액 차감 동시성 제어 - 전체 통합 (Integration)", () => {
+  let ds: DataSource;
+
+  let authSvc: AuthService;
+  let userSvc: UserService;
+  let orderSvc: OrderService;
+
+  let userRepo: Repository<UserEntity>;
+  let productRepo: Repository<ProductEntity>;
+  let orderRepo: Repository<OrderEntity>;
+  let outboxRepo: Repository<OutboxEntity>;
+
+  let userIds: number[];
+  let productId_A: number;
+  let productId_B: number;
+
+  beforeAll(async () => {
+    const { moduleRef, dataSource } = await createItModuleMySql();
+    ds = dataSource;
+
+    authSvc = moduleRef.get(AuthService);
+    userSvc = moduleRef.get(UserService);
+    orderSvc = moduleRef.get(OrderService);
+
+    // 서비스와 **동일 커넥션**의 리포지토리 사용
+    userRepo = moduleRef.get(getRepositoryToken(UserEntity));
+    productRepo = moduleRef.get(getRepositoryToken(ProductEntity));
+    orderRepo = moduleRef.get(getRepositoryToken(OrderEntity));
+    outboxRepo = moduleRef.get(getRepositoryToken(OutboxEntity));
+  });
+
+  beforeEach(async () => {
+    // 매 테스트 독립성 보장
+    await ds.synchronize(true);
+
+    // [Given] 유저 10명 생성
+    const users = await Promise.all(
+      Array.from({ length: 10 }, (_, i) => authSvc.signUp(`사용자${i + 1}`))
+    );
+    userIds = users.map((u) => u.userId);
+  });
+
+  it("성공 시나리오: 동일 유저가 동시에 두 번 결제해도 잔액은 한 번만 차감되어야 한다", async () => {
+    // [Given] 한 명의 참여 유저에게 5,000원 충전
+    await userSvc.chargeBalance(5000, userIds[0]);
+
+    // [Given] A 상품 ( 재고 10개 )
+    await productRepo.save(
+      productRepo.create({
+        name: "A 상품",
+        price: 3000,
+        stock: 10,
+      })
+    );
+    productId_A = (await productRepo.findOneByOrFail({ name: "A 상품" }))
+      .productId;
+
+    // [When] A 상품을 동시에 두 번 주문 시도
+    const results = await Promise.allSettled([
+      orderSvc.execute({
+        userId: userIds[0],
+        items: [{ productId: productId_A, quantity: 1 }],
+      }),
+      orderSvc.execute({
+        userId: userIds[0],
+        items: [{ productId: productId_A, quantity: 1 }],
+      }),
+    ]);
+
+    // [Then] 성공/실패 판별
+    const fulfilledCount = results.filter(
+      (r) => r.status === "fulfilled"
+    ).length;
+    const rejectedCount = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilledCount).toBe(1);
+    expect(rejectedCount).toBe(1);
+
+    // [Then] 잔액 검증 (성공한 유저만 돈 빠졌는지)
+    const uA = await userRepo.findOneByOrFail({ userId: userIds[0] });
+    expect(uA.balance).toBe(2000);
+
+    // [Then] 음수 잔액 방지
+    expect(uA.balance).toBeGreaterThanOrEqual(0);
+
+    // [Then] 주문이 실제로 최소 1건이 생겼는지
+    const allOrders = await orderRepo.find({
+      where: {}, // 전부
+    });
+    expect(allOrders.length).toBe(1);
+    expect(allOrders[0].status).toBe("PAID");
+    expect(allOrders[0].paidAmount).toBe(3000);
+    expect(allOrders[0].user.userId).toBe(userIds[0]);
+  });
+  it("성공 시나리오: 같은 유저가 동시에 두 주문을 넣어도, 보유 잔액(5000원)보다 많이 쓸 수는 없어야 한다", async () => {
+    // [Given] 한 명의 참여 유저에게 5,000원 충전
+    await userSvc.chargeBalance(5000, userIds[0]);
+
+    // [Given] A 상품 ( 재고 10개 )
+    await productRepo.save(
+      productRepo.create({
+        name: "A 상품",
+        price: 3000,
+        stock: 10,
+      })
+    );
+    productId_A = (await productRepo.findOneByOrFail({ name: "A 상품" }))
+      .productId;
+    // [Given] B 상품 ( 재고 10개 )
+    await productRepo.save(
+      productRepo.create({
+        name: "B 상품",
+        price: 3000,
+        stock: 10,
+      })
+    );
+    productId_B = (await productRepo.findOneByOrFail({ name: "B 상품" }))
+      .productId;
+
+    // [When] A와 B 상품을 동시에 주문 시도
+    const results = await Promise.allSettled([
+      orderSvc.execute({
+        userId: userIds[0],
+        items: [{ productId: productId_A, quantity: 1 }],
+      }),
+      orderSvc.execute({
+        userId: userIds[0],
+        items: [{ productId: productId_B, quantity: 1 }],
+      }),
+    ]);
+
+    // [Then] 성공/실패 판별
+    const fulfilledCount = results.filter(
+      (r) => r.status === "fulfilled"
+    ).length;
+    const rejectedCount = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilledCount).toBe(1);
+    expect(rejectedCount).toBe(1);
+
+    // [Then] 잔액 검증 (성공한 유저만 돈 빠졌는지)
+    const uA = await userRepo.findOneByOrFail({ userId: userIds[0] });
+    expect(uA.balance).toBe(2000);
+
+    // [Then] 음수 잔액 방지
+    expect(uA.balance).toBeGreaterThanOrEqual(0);
+
+    // [Then] 주문이 실제로 최소 1건이 생겼는지
+    const allOrders = await orderRepo.find({
+      where: {}, // 전부
+    });
+    expect(allOrders.length).toBe(1);
+    expect(allOrders[0].status).toBe("PAID");
+    expect(allOrders[0].paidAmount).toBe(3000);
+    expect(allOrders[0].user.userId).toBe(userIds[0]);
+  });
+  it("트랜잭션 도중 실패하면 잔액 차감도 롤백되어야 한다", async () => {
+    // [Given] 유저 한 명 (잔액 부족 상태)
+    await userSvc.chargeBalance(1000, userIds[0]);
+
+    // [Given] A 상품 ( 재고 10개 )
+    await productRepo.save(
+      productRepo.create({
+        name: "A 상품",
+        price: 3000,
+        stock: 10,
+      })
+    );
+    productId_A = (await productRepo.findOneByOrFail({ name: "A 상품" }))
+      .productId;
+
+    // [When/Then] 주문 시도 → 실패해야 함
+    await expect(
+      orderSvc.execute({
+        userId: userIds[0],
+        items: [{ productId: productId_A, quantity: 1 }],
+      })
+    ).rejects.toBeDefined();
+
+    // [Then] 잔액 롤백 확인: 여전히 1000이어야 한다
+    const userAfter = await userRepo.findOneByOrFail({ userId: userIds[0] });
+    expect(userAfter.balance).toBe(1000);
+
+    // [Then] 주문이 실제로 만들어지지 않았는지 확인 (DB에 없는지)
+    const orders = await orderRepo.find();
+    expect(orders.length).toBe(0);
+
+    // [Then] outbox에도 이벤트가 남으면 안 된다
+    const outboxRecords = await outboxRepo.find();
+    expect(outboxRecords.length).toBe(0);
+  });
+});

--- a/test/it/order/balance-concurrency.it.spec.ts
+++ b/test/it/order/balance-concurrency.it.spec.ts
@@ -11,10 +11,11 @@ import { UserEntity } from "../../../src/user/entities/user.entity";
 import { ProductEntity } from "../../../src/product/entities/product.entity";
 import { OrderEntity } from "../../../src/order/adapter/out/order.entity";
 import { OutboxEntity } from "../../../src/order/adapter/out/outbox.entity";
+import { TestingModule } from "@nestjs/testing";
 
 describe("잔액 차감 동시성 제어 - 전체 통합 (Integration)", () => {
   let ds: DataSource;
-
+  let moduleRef: TestingModule;
   let authSvc: AuthService;
   let userSvc: UserService;
   let orderSvc: OrderService;
@@ -29,8 +30,9 @@ describe("잔액 차감 동시성 제어 - 전체 통합 (Integration)", () => {
   let productId_B: number;
 
   beforeAll(async () => {
-    const { moduleRef, dataSource } = await createItModuleMySql();
-    ds = dataSource;
+    const setup = await createItModuleMySql();
+    moduleRef = setup.moduleRef;
+    ds = setup.dataSource;
 
     authSvc = moduleRef.get(AuthService);
     userSvc = moduleRef.get(UserService);
@@ -42,7 +44,12 @@ describe("잔액 차감 동시성 제어 - 전체 통합 (Integration)", () => {
     orderRepo = moduleRef.get(getRepositoryToken(OrderEntity));
     outboxRepo = moduleRef.get(getRepositoryToken(OutboxEntity));
   });
-
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy(); // DB 커넥션 풀 닫기
+    }
+    await moduleRef.close(); // Nest 컨테이너 / 내부 타이머 종료
+  });
   beforeEach(async () => {
     // 매 테스트 독립성 보장
     await ds.synchronize(true);
@@ -98,7 +105,8 @@ describe("잔액 차감 동시성 제어 - 전체 통합 (Integration)", () => {
 
     // [Then] 주문이 실제로 최소 1건이 생겼는지
     const allOrders = await orderRepo.find({
-      where: {}, // 전부
+      where: {},
+      relations: ["user"],
     });
     expect(allOrders.length).toBe(1);
     expect(allOrders[0].status).toBe("PAID");
@@ -160,6 +168,7 @@ describe("잔액 차감 동시성 제어 - 전체 통합 (Integration)", () => {
     // [Then] 주문이 실제로 최소 1건이 생겼는지
     const allOrders = await orderRepo.find({
       where: {}, // 전부
+      relations: ["user"],
     });
     expect(allOrders.length).toBe(1);
     expect(allOrders[0].status).toBe("PAID");

--- a/test/it/order/order-payment-flow.it.spec.ts
+++ b/test/it/order/order-payment-flow.it.spec.ts
@@ -11,10 +11,11 @@ import { UserEntity } from "../../../src/user/entities/user.entity";
 import { ProductEntity } from "../../../src/product/entities/product.entity";
 import { OrderEntity } from "../../../src/order/adapter/out/order.entity";
 import { OutboxEntity } from "../../../src/order/adapter/out/outbox.entity";
+import { TestingModule } from "@nestjs/testing";
 
 describe("상품 주문 & 결제 - 전체 통합 (Integration)", () => {
   let ds: DataSource;
-
+  let moduleRef: TestingModule;
   let authSvc: AuthService;
   let userSvc: UserService;
   let orderSvc: OrderService;
@@ -28,8 +29,9 @@ describe("상품 주문 & 결제 - 전체 통합 (Integration)", () => {
   let productId: number;
 
   beforeAll(async () => {
-    const { moduleRef, dataSource } = await createItModule();
-    ds = dataSource;
+    const setup = await createItModule();
+    moduleRef = setup.moduleRef;
+    ds = setup.dataSource;
 
     authSvc = moduleRef.get(AuthService);
     userSvc = moduleRef.get(UserService);
@@ -40,6 +42,13 @@ describe("상품 주문 & 결제 - 전체 통합 (Integration)", () => {
     productRepo = moduleRef.get(getRepositoryToken(ProductEntity));
     orderRepo = moduleRef.get(getRepositoryToken(OrderEntity));
     outboxRepo = moduleRef.get(getRepositoryToken(OutboxEntity));
+  });
+
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy(); // DB 커넥션 풀 닫기
+    }
+    await moduleRef.close(); // Nest 컨테이너 / 내부 타이머 종료
   });
 
   beforeEach(async () => {

--- a/test/it/order/order-payment-flow.it.spec.ts
+++ b/test/it/order/order-payment-flow.it.spec.ts
@@ -83,7 +83,7 @@ describe("상품 주문 & 결제 - 전체 통합 (Integration)", () => {
     const outbox = await outboxRepo.find({
       where: { topic: "order.created" },
     });
-    console.log(outbox);
+
     expect(outbox.length).toBe(1);
     expect(outbox[0].payload).toMatchObject({
       orderId: res.orderId,

--- a/test/it/order/order-publish-fallback.it.spec.ts
+++ b/test/it/order/order-publish-fallback.it.spec.ts
@@ -1,4 +1,4 @@
-import { Test } from "@nestjs/testing";
+import { Test, TestingModule } from "@nestjs/testing";
 import { TypeOrmModule, getRepositoryToken } from "@nestjs/typeorm";
 import { DataSource, Repository } from "typeorm";
 
@@ -15,9 +15,11 @@ import { ProductEntity } from "../../../src/product/entities/product.entity";
 import { OutboxEntity } from "../../../src/order/adapter/out/outbox.entity";
 
 import { MESSAGE_PUBLISHER_PORT } from "../../../src/order/port/out/message-publisher.port";
+import { createItModule } from "../setup";
 
 describe("발행 실패 → Outbox 폴백 (Integration)", () => {
   let ds: DataSource;
+  let moduleRef: TestingModule;
   let authSvc: AuthService;
   let userSvc: UserService;
   let orderSvc: OrderService;
@@ -30,25 +32,9 @@ describe("발행 실패 → Outbox 폴백 (Integration)", () => {
       publish: jest.fn().mockRejectedValue(new Error("publish failed!")),
     };
 
-    const moduleRef = await Test.createTestingModule({
-      imports: [
-        TypeOrmModule.forRoot({
-          type: "sqlite",
-          database: ":memory:",
-          entities: [__dirname + "/../../../src/**/*.entity.{ts,js}"],
-          synchronize: true,
-          dropSchema: true,
-        }),
-        AuthModule,
-        UserModule,
-        OrderModule,
-      ],
-    })
-      .overrideProvider(MESSAGE_PUBLISHER_PORT) // 실패 목으로 교체
-      .useValue(failingPublisher)
-      .compile();
-
-    ds = moduleRef.get(DataSource);
+    const setup = await createItModule();
+    moduleRef = setup.moduleRef;
+    ds = setup.dataSource;
     authSvc = moduleRef.get(AuthService);
     userSvc = moduleRef.get(UserService);
     orderSvc = moduleRef.get(OrderService);
@@ -56,6 +42,12 @@ describe("발행 실패 → Outbox 폴백 (Integration)", () => {
     userRepo = moduleRef.get(getRepositoryToken(UserEntity));
     productRepo = moduleRef.get(getRepositoryToken(ProductEntity));
     outboxRepo = moduleRef.get(getRepositoryToken(OutboxEntity));
+  });
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy(); // DB 커넥션 풀 닫기
+    }
+    await moduleRef.close(); // Nest 컨테이너 / 내부 타이머 종료
   });
 
   beforeEach(async () => {

--- a/test/it/order/stock-concurrency.it.spec.ts
+++ b/test/it/order/stock-concurrency.it.spec.ts
@@ -11,10 +11,11 @@ import { UserEntity } from "../../../src/user/entities/user.entity";
 import { ProductEntity } from "../../../src/product/entities/product.entity";
 import { OrderEntity } from "../../../src/order/adapter/out/order.entity";
 import { OutboxEntity } from "../../../src/order/adapter/out/outbox.entity";
+import { TestingModule } from "@nestjs/testing";
 
 describe("재고 감소 동시성 제어 - 전체 통합 (Integration)", () => {
   let ds: DataSource;
-
+  let moduleRef: TestingModule;
   let authSvc: AuthService;
   let userSvc: UserService;
   let orderSvc: OrderService;
@@ -29,8 +30,9 @@ describe("재고 감소 동시성 제어 - 전체 통합 (Integration)", () => {
   let productId_B: number;
 
   beforeAll(async () => {
-    const { moduleRef, dataSource } = await createItModuleMySql();
-    ds = dataSource;
+    const setup = await createItModuleMySql();
+    moduleRef = setup.moduleRef;
+    ds = setup.dataSource;
 
     authSvc = moduleRef.get(AuthService);
     userSvc = moduleRef.get(UserService);
@@ -42,7 +44,12 @@ describe("재고 감소 동시성 제어 - 전체 통합 (Integration)", () => {
     orderRepo = moduleRef.get(getRepositoryToken(OrderEntity));
     outboxRepo = moduleRef.get(getRepositoryToken(OutboxEntity));
   });
-
+  afterAll(async () => {
+    if (ds?.isInitialized) {
+      await ds.destroy(); // DB 커넥션 풀 닫기
+    }
+    await moduleRef.close(); // Nest 컨테이너 / 내부 타이머 종료
+  });
   beforeEach(async () => {
     // 매 테스트 독립성 보장
     await ds.synchronize(true);
@@ -296,4 +303,14 @@ describe("재고 감소 동시성 제어 - 전체 통합 (Integration)", () => {
     const outboxRecords = await outboxRepo.find();
     expect(outboxRecords.length).toBe(0);
   });
+
+  // afterAll(async () => {
+  //   // 1) DB 커넥션 닫기
+  //   if (ds && ds.isInitialized) {
+  //     await ds.destroy();
+  //   }
+
+  //   // 2) Nest 모듈 닫기 (내부 provider 들의 onModuleDestroy / onApplicationShutdown를 호출하게 됨)
+  //   await moduleRef.close();
+  // });
 });

--- a/test/it/order/stock-concurrency.it.spec.ts
+++ b/test/it/order/stock-concurrency.it.spec.ts
@@ -1,0 +1,299 @@
+// test/it/order/order-payment-flow.it.spec.ts
+import { createItModuleMySql } from "../setup.mysql";
+import { DataSource, Repository } from "typeorm";
+import { getRepositoryToken } from "@nestjs/typeorm";
+
+import { AuthService } from "../../../src/auth/auth.service";
+import { UserService } from "../../../src/user/user.service";
+import { OrderService } from "../../../src/order/usecase/order.service";
+
+import { UserEntity } from "../../../src/user/entities/user.entity";
+import { ProductEntity } from "../../../src/product/entities/product.entity";
+import { OrderEntity } from "../../../src/order/adapter/out/order.entity";
+import { OutboxEntity } from "../../../src/order/adapter/out/outbox.entity";
+
+describe("재고 감소 동시성 제어 - 전체 통합 (Integration)", () => {
+  let ds: DataSource;
+
+  let authSvc: AuthService;
+  let userSvc: UserService;
+  let orderSvc: OrderService;
+
+  let userRepo: Repository<UserEntity>;
+  let productRepo: Repository<ProductEntity>;
+  let orderRepo: Repository<OrderEntity>;
+  let outboxRepo: Repository<OutboxEntity>;
+
+  let userIds: number[];
+  let productId_A: number;
+  let productId_B: number;
+
+  beforeAll(async () => {
+    const { moduleRef, dataSource } = await createItModuleMySql();
+    ds = dataSource;
+
+    authSvc = moduleRef.get(AuthService);
+    userSvc = moduleRef.get(UserService);
+    orderSvc = moduleRef.get(OrderService);
+
+    // 서비스와 **동일 커넥션**의 리포지토리 사용
+    userRepo = moduleRef.get(getRepositoryToken(UserEntity));
+    productRepo = moduleRef.get(getRepositoryToken(ProductEntity));
+    orderRepo = moduleRef.get(getRepositoryToken(OrderEntity));
+    outboxRepo = moduleRef.get(getRepositoryToken(OutboxEntity));
+  });
+
+  beforeEach(async () => {
+    // 매 테스트 독립성 보장
+    await ds.synchronize(true);
+
+    // [Given] 유저 10명 생성
+    const users = await Promise.all(
+      Array.from({ length: 10 }, (_, i) => authSvc.signUp(`사용자${i + 1}`))
+    );
+    userIds = users.map((u) => u.userId);
+  });
+
+  it("성공 시나리오: 재고가 1개 남은 상태에서 2명이 주문하면 한명만 성공하고 재고는 0이 된다", async () => {
+    // [Given] 두 참여 유저에게 5,000원씩 충전
+    await userSvc.chargeBalance(5000, userIds[0]);
+    await userSvc.chargeBalance(5000, userIds[1]);
+
+    // [Given] A 상품 ( 재고 1개 )
+    await productRepo.save(
+      productRepo.create({
+        name: "A 상품",
+        price: 3000,
+        stock: 1,
+      })
+    );
+    productId_A = (await productRepo.findOneByOrFail({ name: "A 상품" }))
+      .productId;
+
+    // [When] A 상품을 동시에 주문 시도 (동일 상품, 수량 1)
+    const [r1, r2] = await Promise.allSettled([
+      orderSvc.execute({
+        userId: userIds[0],
+        items: [{ productId: productId_A, quantity: 1 }],
+      }),
+      orderSvc.execute({
+        userId: userIds[1],
+        items: [{ productId: productId_A, quantity: 1 }],
+      }),
+    ]);
+
+    // [Then] 성공/실패 판별
+    const results = [r1, r2];
+    const fulfilledCount = results.filter(
+      (r) => r.status === "fulfilled"
+    ).length;
+    const rejectedCount = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilledCount).toBe(1);
+    expect(rejectedCount).toBe(1);
+
+    // [Then] 잔액 검증 (성공한 유저만 돈 빠졌는지)
+    const uA = await userRepo.findOneByOrFail({ userId: userIds[0] });
+    const uB = await userRepo.findOneByOrFail({ userId: userIds[1] });
+    const balances = [uA.balance, uB.balance].sort(); // 작은 값이 먼저 오게
+    expect(balances).toEqual([2000, 5000]);
+
+    // [Then] 최종 재고는 0이어야 한다 (음수면 안됨, 1이면 oversell 안 된 거 아님)
+    const productAfter = await productRepo.findOneByOrFail({
+      productId: productId_A,
+    });
+    expect(productAfter.stock).toBe(0);
+  });
+
+  it("성공 시나리오: 재고가 정확히 10개일 때 5명이 동시에 주문하면 모두 성공하고 재고는 5가 된다", async () => {
+    // [Given] 모든 참여 유저에게 5,000원씩 충전
+    await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        userSvc.chargeBalance(5000, userIds[i])
+      )
+    );
+    // [Given] B 상품 ( 재고 10 개 )
+    await productRepo.save(
+      productRepo.create({
+        name: "B 상품",
+        price: 3000,
+        stock: 10,
+      })
+    );
+    productId_B = (await productRepo.findOneByOrFail({ name: "B 상품" }))
+      .productId;
+
+    // [When] 동시에 주문 시도 (동일 상품, 수량 1)
+    const results = await Promise.allSettled(
+      userIds.slice(0, 5).map((id) =>
+        orderSvc.execute({
+          userId: id,
+          items: [{ productId: productId_B, quantity: 1 }],
+        })
+      )
+    );
+
+    // [Then] 성공/실패 판별
+    const fulfilledCount = results.filter(
+      (r) => r.status === "fulfilled"
+    ).length;
+    const rejectedCount = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilledCount).toBe(5);
+    expect(rejectedCount).toBe(0);
+
+    // [Then] 잔액 검증 (성공한 유저만 돈 빠졌는지)
+    const usersAfter = await Promise.all(
+      userIds.slice(0, 5).map((id) => userRepo.findOneByOrFail({ userId: id }))
+    );
+    const balances = usersAfter.map((u) => u.balance).sort();
+    expect(balances).toEqual([2000, 2000, 2000, 2000, 2000]);
+
+    // [Then] 최종 재고는 5이어야 한다
+    const productAfter = await productRepo.findOneByOrFail({
+      productId: productId_B,
+    });
+    expect(productAfter.stock).toBe(5);
+  });
+
+  it("성공 시나리오: 재고가 정확히 10개일 때 10명이 동시에 주문하면 모두 성공하고 재고는 0이 된다", async () => {
+    // [Given] 모든 참여 유저에게 5,000원씩 충전
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        userSvc.chargeBalance(5000, userIds[i])
+      )
+    );
+    // [Given] B 상품 ( 재고 10 개 )
+    await productRepo.save(
+      productRepo.create({
+        name: "B 상품",
+        price: 3000,
+        stock: 10,
+      })
+    );
+    productId_B = (await productRepo.findOneByOrFail({ name: "B 상품" }))
+      .productId;
+
+    // [When] 동시에 주문 시도 (동일 상품, 수량 1)
+    const results = await Promise.allSettled(
+      userIds.slice(0, 10).map((id) =>
+        orderSvc.execute({
+          userId: id,
+          items: [{ productId: productId_B, quantity: 1 }],
+        })
+      )
+    );
+
+    // [Then] 성공/실패 판별
+    const fulfilledCount = results.filter(
+      (r) => r.status === "fulfilled"
+    ).length;
+    const rejectedCount = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilledCount).toBe(10);
+    expect(rejectedCount).toBe(0);
+
+    // [Then] 잔액 검증 (성공한 유저만 돈 빠졌는지)
+    const usersAfter = await Promise.all(
+      userIds.slice(0, 10).map((id) => userRepo.findOneByOrFail({ userId: id }))
+    );
+    const balances = usersAfter.map((u) => u.balance).sort();
+    expect(balances).toEqual([
+      2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000,
+    ]);
+
+    // [Then] 최종 재고는 0이어야 한다
+    const productAfter = await productRepo.findOneByOrFail({
+      productId: productId_B,
+    });
+    expect(productAfter.stock).toBe(0);
+  });
+
+  it("재고 5개에서 동시에 3개씩 요청하면 한 요청만 성공하고 재고는 2가 된다", async () => {
+    // [Given] 유저 2명, 각각 충분한 잔액
+    const u1 = userIds[0];
+    const u2 = userIds[1];
+    await userSvc.chargeBalance(10000, u1);
+    await userSvc.chargeBalance(10000, u2);
+
+    // [Given] C 상품 ( 재고 5개 )
+    const cProduct = await productRepo.save(
+      productRepo.create({
+        name: "C 상품",
+        price: 3000,
+        stock: 5,
+      })
+    );
+    const productId_C = cProduct.productId;
+
+    // [When] 동시에 quantity=3 주문
+    const [r1, r2] = await Promise.allSettled([
+      orderSvc.execute({
+        userId: u1,
+        items: [{ productId: productId_C, quantity: 3 }],
+      }),
+      orderSvc.execute({
+        userId: u2,
+        items: [{ productId: productId_C, quantity: 3 }],
+      }),
+    ]);
+
+    const results = [r1, r2];
+    const fulfilledCount = results.filter(
+      (r) => r.status === "fulfilled"
+    ).length;
+    const rejectedCount = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilledCount).toBe(1);
+    expect(rejectedCount).toBe(1);
+
+    // [Then] 재고 확인
+    const productAfter = await productRepo.findOneByOrFail({
+      productId: productId_C,
+    });
+    expect(productAfter.stock).toBe(2); // 5 - 3
+
+    // [Then] 잔액 확인 (성공자만 결제됨)
+    const afterU1 = await userRepo.findOneByOrFail({ userId: u1 });
+    const afterU2 = await userRepo.findOneByOrFail({ userId: u2 });
+    const balances = [afterU1.balance, afterU2.balance].sort();
+    // 한 명은 10000- (3 * 3000 = 9000) = 1000
+    // 한 명은 여전히 10000
+    expect(balances).toEqual([1000, 10000]);
+  });
+
+  it("트랜잭션 도중 실패하면 재고 차감도 롤백되어야 한다", async () => {
+    // [Given] 유저 한 명 (잔액 부족 상태)
+    const u = userIds[0];
+    // 충전 안 함, 또는 아주 적게만 충전
+    await userSvc.chargeBalance(1000, u); // 상품은 3000원이라 일부러 부족
+
+    // [Given] D 상품(stock=5, price=3000)
+    const dProduct = await productRepo.save(
+      productRepo.create({
+        name: "D 상품",
+        price: 3000,
+        stock: 5,
+      })
+    );
+    const productId_D = dProduct.productId;
+
+    // [When/Then] 주문 시도 → 실패해야 함
+    await expect(
+      orderSvc.execute({
+        userId: u,
+        items: [{ productId: productId_D, quantity: 1 }],
+      })
+    ).rejects.toBeDefined();
+
+    // [Then] 재고 롤백 확인: 여전히 5여야 한다
+    const productAfter = await productRepo.findOneByOrFail({
+      productId: productId_D,
+    });
+    expect(productAfter.stock).toBe(5);
+
+    // [Then] 주문이 실제로 만들어지지 않았는지 확인 (DB에 없는지)
+    const orders = await orderRepo.find();
+    expect(orders.length).toBe(0);
+
+    // [Then] outbox에도 이벤트가 남으면 안 된다
+    const outboxRecords = await outboxRepo.find();
+    expect(outboxRecords.length).toBe(0);
+  });
+});

--- a/test/it/setup.mysql.ts
+++ b/test/it/setup.mysql.ts
@@ -1,0 +1,36 @@
+// test/it/setup.mysql.ts
+import { Test } from "@nestjs/testing";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { DataSource } from "typeorm";
+
+import { UserModule } from "../../src/user/user.module";
+import { OrderModule } from "../../src/order/module/order.module";
+import { AuthModule } from "../../src/auth/auth.module";
+import * as dotenv from "dotenv";
+dotenv.config();
+export async function createItModuleMySql() {
+    const moduleRef = await Test.createTestingModule({
+        imports: [
+        TypeOrmModule.forRoot({
+            type: "mysql",
+            host: process.env.DB_HOST ?? "localhost",
+            port: +(process.env.DB_PORT ?? 3306),
+            username: process.env.DB_USER ?? "root",
+            password: process.env.DB_PASS ?? "aaaa1357",
+            database: process.env.DB_NAME ?? "ecom_test",
+            // Nest + TypeORM 패턴
+            autoLoadEntities: true,
+            synchronize: true,       // 테스트 환경에서는 true 허용
+            dropSchema: true,        // 매 테스트 전에 clean하게 쓸 수 있게
+        }),
+        UserModule,
+        OrderModule,
+        AuthModule,
+        ],
+    }).compile();
+
+    return {
+        moduleRef,
+        dataSource: moduleRef.get(DataSource),
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2480,10 +2480,10 @@ dotenv@^16.0.3:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
 
-dotenv@^17.2.1:
-  version "17.2.1"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz"
-  integrity sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==
+dotenv@^17.2.3:
+  version "17.2.3"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz"
+  integrity sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==
 
 dotenv@16.4.1:
   version "16.4.1"


### PR DESCRIPTION
# 변경사항


## 1. 재고 감소 동시성 제어 테스트 3e21869862633138ba58fe30674c4a8f97ca1db5

 ### 같은 상품을 여러 사용자가 동시에 결제하려고 할 때
- “한정 수량 1개”에서 두 명이 동시에 결제 → 한 명만 성공해야 한다.
- 재고 10개에서 5명 동시 주문 → 모두 성공해야 한다.
- 재고 10개에서 10명 동시 주문 → 모두 성공해야 한다(완판).
- 재고 5개에서 두 명이 각각 3개씩 동시에 주문 → 한 요청만 성공해야 한다.

### 잔액 부족 등으로 결제가 중간에 실패하면

- 이미 차감한 재고도 반드시 되돌아와야 한다.
- 잘못된 주문 레코드가 DB에 남으면 안 된다.
- Outbox(이벤트 발행용 로그)에도 기록이 남으면 안 된다


## 2. 잔액 차감 동시성 제어 테스트 6d77f3f63ea5bdf01810dbfc23770a9317087eca

### 동일 사용자가 동시에 여러 번 결제를 시도할 때

- 같은 사용자가 같은 상품을 거의 동시에 두 번 결제 요청을 보내더라도 → 실제로는 한 번만 결제가 승인되어야 한다.
- 같은 사용자가 서로 다른 상품을 동시에 주문하더라도 → 본인이 가진 잔액 이상을 쓸 수 있으면 안 된다.

### 잔액 부족 등으로 결제가 중간에 실패하면

- 이미 차감된 잔액도 반드시 원래 금액으로 되돌아와야 한다.
- 잘못된 주문 레코드가 DB에 남으면 안 된다.
- Outbox(이벤트 발행용 로그)에도 기록이 남으면 안 된다.

<img width="844" height="329" alt="Image" src="https://github.com/user-attachments/assets/105312b7-b7aa-48d1-abaa-7a3a7f4db0c9" />

# 리뷰받고 싶은점

제가 상황에 맞게 테스트를 잘 했는지, 또한 테스트할 부분이 더 있었는지 리뷰받고 싶습니다.

# 느낀점

과제에서는 조건부 UPDATE나 **SELECT ... FOR UPDATE**를 사용하라고 되어 있었지만,
ORM을 사용하는 입장에서 이를 어떻게 적용해야 할지 처음에는 잘 감이 오지 않았습니다.

그러던 중 TypeORM의 decrement 메서드가 내부적으로 UPDATE 쿼리를 수행한다는 것을 확인하게 되었고,
이미 원자적인 감소 연산이 보장된다는 점을 알게 되었습니다.
따라서 별도의 락이나 쿼리 수정 없이 현재 구조를 유지한 채 테스트 코드 작성으로 바로 넘어갔습니다.

또한 쿠폰 발급 기능은 선택 과제라고 판단해 지금까지는 제외해왔지만,
향후 서비스 흐름상 반드시 필요할 것으로 보여 추가 구현을 진행할 예정입니다.

따끔한 리뷰 부탁드립니다!
